### PR TITLE
feat: add option for custom hash lib

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,16 @@ var r = require('rethinkdb');
  * RethinkDBStore constructor
  * @param {Object} options RethinkDB options
  */
-function RethinkDBStore(options) {
+function RethinkDBStore(options, hashLib) {
     this.options = options || {};
+    this.hashLib = hashLib || {
+        hash: function(token, cb) {
+            bcrypt.hash(token, 10, cb);
+        },
+        verify: function(token, hashedToken, cb) {
+            bcrypt.compare(token, hashedToken, cb);
+        }
+    };
     TokenStore.call(this);
     this.connection = null;
 };
@@ -57,11 +65,12 @@ RethinkDBStore.prototype.authenticate = function authenticate(token, uid, callba
     if(!token || !uid || !callback) {
         throw new Error('TokenStore:authenticate called with invalid parameters');
     }
+    var hashLib = this.hashLib;
     this.getConnection(function (conn) {
         r.table('pwdless').get(uid).run(conn, function (err, doc) {
             if (err) return callback(err, false, null);
             if (doc == null || doc.ttl < Date.now()) return callback(null, false, null);
-            bcrypt.compare(token, doc.hashedToken, function (err, res) {
+            hashLib.verify(token, doc.hashedToken, function (err, res) {
                 if (err) return callback(err, false, null);
                 if (res) return callback(null, true, doc.originUrl);
                 return callback(null, false, null);
@@ -86,8 +95,9 @@ RethinkDBStore.prototype.storeOrUpdate = function(token, uid, msToLive, originUr
         throw new Error('TokenStore:storeOrUpdate called with invalid parameters');
     }
 
+    var hashLib = this.hashLib;
     this.getConnection(function (conn) {
-        bcrypt.hash(token, 10, function (err, hashedToken) {
+        hashLib.hash(token, function (err, hashedToken) {
             if (err) return callback(err);
             var newRecord = {
                 id: uid,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "rethinkdb": "2.3.3"
   },
   "devDependencies": {
+    "argon2": "^0.14.0",
     "chai": "^2.3.0",
     "mocha": "^2.0.0",
     "node-uuid": "^1.4.3",


### PR DESCRIPTION
Hey @kvnneff,
I think, users of this lib should be able to decide which hashing library they want to use.
At the moment, users are stuck to use bcrypt (which is a sane default, don't get me wrong), but there are other alternatives out there, e.g. [Argon2](https://password-hashing.net/argon2-specs.pdf), which is the winner of the [Password Hashing Competition](https://password-hashing.net/) of 2015. It uses memory hard functions in order to make it even more expensive for an attacker to crack a hashed password.

This PR introduces an **optional argument** in the ctor for an object with a `hash` and `verify` function in order to allow a user to use any hashing library simply by specifying these two functions. An example of specifying these two functions can be seen in the tests where Argon2 (see above) is used.

Because this change is totally backward compatible (argument is optional), I see this as a minor version upgrade. If this PR gets merged, I will update the documentation accordingly. After documentation is ready, we can bump the version.

In the near future, I will also get in contact with @florianheinemann and see whether we can make this a "standard" in the [passwordless library](https://github.com/florianheinemann/passwordless).