### PR TITLE
docs: document usage of custom hashing library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var r = require('rethinkdb');
 /**
  * RethinkDBStore constructor
  * @param {Object} options RethinkDB options
+ * @param {Object} hashLib Hash and verify function for the token
  */
 function RethinkDBStore(options, hashLib) {
     this.options = options || {};

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This module provides token storage for [Passwordless](https://github.com/florianheinemann/passwordless), a node.js module for express that allows website authentication without password using verification through email or other means. Visit the project's [website](https://passwordless.net) for more details.
 
-Tokens are stored in a RethinkDB database and are hashed and salted using [bcrypt](https://github.com/ncb000gt/node.bcrypt.js/).
+Tokens are stored in a RethinkDB database and are hashed and salted using [bcrypt](https://github.com/ncb000gt/node.bcrypt.js/) by default. It is also possible to provide a different hashing library (see [Initialization](#initialization) for an example).
 
 ## Usage
 
@@ -30,12 +30,38 @@ app.use(passwordless.acceptToken());
 ## Initialization
 
 ```javascript
-new RethinkDBStore([options]);
+new RethinkDBStore([options], [hashLib]);
 ```
 * **[options]:** *(Object)* Optional. This can include options of the node.js RethinkDB client as described in the [docs](http://www.rethinkdb.com/api/javascript/#connect).
+* **[hashLib]** *(Object)* Optional. This can be specified in order to provide a custom hashing library. This object takes two functions: `hash(token, cb)` and `verify(token, hashedToken, cb)`. The following example uses the hashing library [Argon2](https://github.com/ranisalt/node-argon2).
+```javascript
+var argon2 = require('argon2');
+var store = new RethinkDBStore([options], {
+    hash: function(token, cb) {
+        argon2.generateSalt()
+            .then(function(salt) {
+                argon2.hash(token, salt)
+                .then(cb.bind(null, null))
+                .catch(cb);
+            });
+    },
+    verify: function(token, hashedToken, cb) {
+        argon2.verify(hashedToken, token)
+            .then(function(match) {
+                if (match) {
+                    return cb(null, match);
+                }
+                else {
+                    return cb();
+                }
+            })
+            .catch(cb);
+    }
+});
+```
 
 ## Hash and salt
-As the tokens are equivalent to passwords (even though only for a limited time) they have to be protected in the same way. passwordless-rethinkdbstore uses [bcrypt](https://github.com/ncb000gt/node.bcrypt.js/) with automatically created random salts. To generate the salt 10 rounds are used.
+As the tokens are equivalent to passwords (even though only for a limited time) they have to be protected in the same way. By default passwordless-rethinkdbstore uses [bcrypt](https://github.com/ncb000gt/node.bcrypt.js/) with automatically created random salts. To generate the salt 10 rounds are used. Alternatively, a custom `hash` and `verify` function can be specified (see [Initialization](#initialization)), which should call the respective functions of some secure hashing library (e.g. [Argon2](https://github.com/ranisalt/node-argon2), winner of the [Password Hashing Competition](https://password-hashing.net) 2015).
 
 ## Tests
 


### PR DESCRIPTION
This documents the usage of specifying a custom hashing library for hashing and verifying the token.
The option for specifying a custom hashing library has been introduced in 60ffe68.